### PR TITLE
Add statistical evaluation of case-control matches

### DIFF
--- a/qupid/_casematch_utils.py
+++ b/qupid/_casematch_utils.py
@@ -83,7 +83,7 @@ def _match_discrete(
     return np.array(focus_value == background_values)
 
 
-def _load_mapping(path: str) -> Dict[str, set]:
+def _load(path: str) -> Dict[str, set]:
     """Load mapping file from JSON as dict.
 
     :param path: Location of filepath

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -7,7 +7,6 @@ from warnings import warn
 from joblib import Parallel, delayed
 import networkx as nx
 import pandas as pd
-from skbio import DistanceMatrix
 
 from qupid import _exceptions as exc
 from qupid.matching import hopcroft_karp_matching
@@ -15,11 +14,10 @@ import qupid._casematch_utils as util
 
 
 class _BaseCaseMatch(ABC):
-    __slots__ = "case_control_map", "metadata", "distance_matrix"
+    __slots__ = "case_control_map", "metadata"
 
     def __init__(self, case_control_map: Dict[str, set],
-                 metadata: Union[pd.Series, pd.DataFrame] = None,
-                 distance_matrix: DistanceMatrix = None):
+                 metadata: Union[pd.Series, pd.DataFrame] = None):
         """Base class storing case-control data & metadata.
 
         :param case_control_map: Dict of cases to sets of controls
@@ -27,18 +25,11 @@ class _BaseCaseMatch(ABC):
 
         :param metadata: Metadata associated with cases & controls (optional)
         :type metadata: pd.Series or pd.DataFrame
-
-        :param distance_matrix: Beta-diversity distance matrix of cases and
-            controls (optional)
-        :type distance_matrix: skbio.DistanceMatrix
         """
         self.case_control_map = case_control_map
         cases = set(case_control_map.keys())
         controls = reduce(lambda x, y: x.union(y), case_control_map.values())
-        if distance_matrix is not None:
-            util._validate_distance_matrix(cases, controls, distance_matrix)
         self.metadata = metadata
-        self.distance_matrix = distance_matrix
 
     @property
     def cases(self) -> Set[str]:
@@ -76,8 +67,7 @@ class _BaseCaseMatch(ABC):
 
 class CaseMatchOneToMany(_BaseCaseMatch):
     def __init__(self, case_control_map: Dict[str, set],
-                 metadata: Union[pd.Series, pd.DataFrame] = None,
-                 distance_matrix: DistanceMatrix = None):
+                 metadata: Union[pd.Series, pd.DataFrame] = None):
         """Case match object for mapping one case to multiple controls.
 
         :param case_control_map: Dict of cases to sets of controls
@@ -85,12 +75,8 @@ class CaseMatchOneToMany(_BaseCaseMatch):
 
         :param metadata: Metadata associated with cases & controls (optional)
         :type metadata: pd.Series or pd.DataFrame
-
-        :param distance_matrix: Beta-diversity distance matrix of cases and
-            controls (optional)
-        :type distance_matrix: skbio.DistanceMatrix
         """
-        super().__init__(case_control_map, metadata, distance_matrix)
+        super().__init__(case_control_map, metadata)
 
     @classmethod
     def load_mapping(cls, path: str) -> "CaseMatchOneToMany":
@@ -176,8 +162,7 @@ class CaseMatchOneToMany(_BaseCaseMatch):
 
 class CaseMatchOneToOne(_BaseCaseMatch):
     def __init__(self, case_control_map: Dict[str, set],
-                 metadata: Union[pd.Series, pd.DataFrame] = None,
-                 distance_matrix: DistanceMatrix = None):
+                 metadata: Union[pd.Series, pd.DataFrame] = None):
         """Case match object for mapping one case to one control.
 
         :param case_control_map: Dict of cases to sets of controls
@@ -185,14 +170,10 @@ class CaseMatchOneToOne(_BaseCaseMatch):
 
         :param metadata: Metadata associated with cases & controls (optional)
         :type metadata: pd.Series or pd.DataFrame
-
-        :param distance_matrix: Beta-diversity distance matrix of cases and
-            controls (optional)
-        :type distance_matrix: skbio.DistanceMatrix
         """
         if not util._check_one_to_one(case_control_map):
             raise exc.NotOneToOneError(case_control_map)
-        super().__init__(case_control_map, metadata, distance_matrix)
+        super().__init__(case_control_map, metadata)
 
     @classmethod
     def load_mapping(cls, path: str) -> "CaseMatchOneToOne":
@@ -327,5 +308,5 @@ def match_by_multiple(
 def _get_cm(cm, G, strict):
     M = cm._create_matched_pairs_single(G, cases=cm.cases,
                                         strict=strict)
-    cm = CaseMatchOneToOne(M, cm.metadata, cm.distance_matrix)
+    cm = CaseMatchOneToOne(M, cm.metadata)
     return cm

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -332,6 +332,10 @@ class CaseMatchCollection:
             casematches.append(CaseMatchOneToOne(mapping))
         return cls(casematches)
 
+    def save(self, path):
+        df = self.to_dataframe()
+        df.to_csv(path, sep="\t", index=True)
+
     def __next__(self):
         if self._n >= len(self.case_matches):
             raise StopIteration

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -323,6 +323,15 @@ class CaseMatchCollection:
         df.index.name = "case_id"
         return df
 
+    @classmethod
+    def load(cls, path):
+        df = pd.read_table(path, sep="\t", index_col=0)
+        casematches = []
+        for col in df.columns:
+            mapping = {k: {v} for k, v in df[col].to_dict().items()}
+            casematches.append(CaseMatchOneToOne(mapping))
+        return cls(casematches)
+
     def __next__(self):
         if self._n >= len(self.case_matches):
             raise StopIteration

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -53,7 +53,7 @@ class _BaseCaseMatch(ABC):
 
     @classmethod
     @abstractmethod
-    def load_mapping(cls, path: str):
+    def load(cls, path: str):
         """Create CaseMatch object from JSON file."""
 
     def __getitem__(self, case_name: str) -> set:
@@ -77,8 +77,8 @@ class CaseMatchOneToMany(_BaseCaseMatch):
         super().__init__(case_control_map, metadata)
 
     @classmethod
-    def load_mapping(cls, path: str) -> "CaseMatchOneToMany":
-        cm = util._load_mapping(path)
+    def load(cls, path: str) -> "CaseMatchOneToMany":
+        cm = util._load(path)
         return cls(cm)
 
     # https://www.python.org/dev/peps/pep-0484/#forward-references
@@ -174,8 +174,8 @@ class CaseMatchOneToOne(_BaseCaseMatch):
         super().__init__(case_control_map, metadata)
 
     @classmethod
-    def load_mapping(cls, path: str) -> "CaseMatchOneToOne":
-        cm = util._load_mapping(path)
+    def load(cls, path: str) -> "CaseMatchOneToOne":
+        cm = util._load(path)
         if not util._check_one_to_one(cm):
             raise exc.NotOneToOneError(cm)
         return cls(cm)

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -103,7 +103,7 @@ class CaseMatchOneToMany(_BaseCaseMatch):
             warning. Defaults to True.
         :type strict: bool
 
-        :param n_jobs: Number of jobs to run in parallel, defaults to None
+        :param n_jobs: Number of jobs to run in parallel, defaults to 1
             (single CPU)
         :type n_jobs: int
 
@@ -112,8 +112,8 @@ class CaseMatchOneToMany(_BaseCaseMatch):
             https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html
         :type parallel_args: dict
 
-        :returns: New CaseMatch object with only one control per case
-        :rtype: qupid.CaseMatchOneToOne
+        :returns: Collection of unique CaseMatchOneToOne objects
+        :rtype: qupid.CaseMatchCollection
         """
         if parallel_args is None:
             parallel_args = dict()

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -315,6 +315,11 @@ def match_by_multiple(
 
 class CaseMatchCollection:
     def __init__(self, case_matches: List[CaseMatchOneToOne] = None):
+        def is_valid_cm(x):
+            return isinstance(x, CaseMatchOneToOne)
+
+        if not all(map(is_valid_cm, case_matches)):
+            raise ValueError("Entries must all be of type CaseMatchOneToOne!")
         self.case_matches = case_matches
 
     def to_dataframe(self):

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -26,6 +26,8 @@ class _BaseCaseMatch(ABC):
         :param metadata: Metadata associated with cases & controls (optional)
         :type metadata: pd.Series or pd.DataFrame
         """
+        if not self._validate_input(case_control_map):
+            raise ValueError("Invalid input!")
         self.case_control_map = case_control_map
         self.metadata = metadata
 
@@ -39,6 +41,18 @@ class _BaseCaseMatch(ABC):
         """Get names of all controls."""
         ccm = self.case_control_map
         return reduce(lambda x, y: x.union(y), ccm.values())
+
+    @staticmethod
+    def _validate_input(case_control_map):
+        def is_ctrl_set_valid(ctrls):
+            return (
+                isinstance(ctrls, set) and
+                all(map(lambda x: isinstance(x, str), ctrls))
+            )
+
+        cases_valid = map(lambda x: isinstance(x, str), case_control_map.keys())
+        ctrls_valid = map(is_ctrl_set_valid, case_control_map.values())
+        return all(cases_valid) and all(ctrls_valid)
 
     def save_mapping(self, path: str) -> None:
         """Saves case-control mapping to file as JSON.

--- a/qupid/stats.py
+++ b/qupid/stats.py
@@ -1,0 +1,159 @@
+from typing import Callable
+
+from joblib import Parallel, delayed
+import pandas as pd
+import scipy.stats as ss
+from skbio import DistanceMatrix
+from skbio.stats.distance import permanova
+
+from qupid.casematch import CaseMatchCollection, CaseMatchOneToOne
+
+
+def bulk_permanova(
+    casematches: CaseMatchCollection,
+    distance_matrix: DistanceMatrix,
+    permutations: int = 999,
+    n_jobs: int = 1,
+    parallel_args: dict = None
+) -> pd.DataFrame:
+    """Evaluate PERMANOVA on multiple case-control mappings.
+
+    :param casematches: Mappings of cases to controls
+    :type casematches: qupid.CaseMatchCollection
+
+    :param distance_matrix: Distance matrix of cases and controls
+    :type distance_matrix: skbio.DistanceMatrix
+
+    :param permutations: Number of PERMANOVA permutations, defaults to 999
+    :type permutations: int
+
+    :param n_jobs: Number of jobs to run in parallel, defaults to 1
+        (single CPU)
+    :type n_jobs: int
+
+    :param parallel_args: Dictionary of arguments to be passed into
+        joblib.Parallel. See the documentation for this class at
+        https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html
+    :type parallel_args: dict
+
+    :returns: PERMANOVA results for all mappings
+    :rtype: pd.DataFrame
+    """
+    if parallel_args is None:
+        parallel_args = dict()
+
+    pnova_results = Parallel(n_jobs=n_jobs, **parallel_args)(
+        delayed(_single_permanova)(cm, distance_matrix)
+        for cm in casematches
+    )
+    pnova_results = pd.DataFrame.from_records(pnova_results)
+    pnova_results.columns = [
+        x.replace(" ", "_") for x in pnova_results.columns
+    ]
+    pnova_results = pnova_results.sort_values(by="test_statistic",
+                                              ascending=False)
+    return pnova_results
+
+
+def bulk_univariate_test(
+    casematches: CaseMatchCollection,
+    values: pd.Series,
+    test: str = "t",
+    n_jobs: int = 1,
+    parallel_args: dict = None
+):
+    """Evaluate univariate test on multiple case-control mappings.
+
+    :param casematches: Mappings of cases to controls
+    :type casematches: qupid.CaseMatchCollection
+
+    :param values: Numeric values to be used for statistical test
+    :type values: pd.Series
+
+    :param test: Statistical test to use, either 't' for independent t-test or
+        'mw' for Mann-Whitney, defaults to 't'
+    :type test: str
+
+    :param n_jobs: Number of jobs to run in parallel, defaults to 1
+        (single CPU)
+    :type n_jobs: int
+
+    :param parallel_args: Dictionary of arguments to be passed into
+        joblib.Parallel. See the documentation for this class at
+        https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html
+    :type parallel_args: dict
+
+    :returns: Test results for all mappings
+    :rtype: pd.DataFrame
+    """
+    if test in ["t", "ttest", "t-test"]:
+        test_fn = ss.ttest_ind
+    elif test in ["mw", "mannwhitney", "mann-whitney"]:
+        test_fn = ss.mannwhitneyu
+    else:
+        raise ValueError(
+            "test must be either 't' (t-test) or 'mw' (Mann-Whitney)"
+        )
+
+    if parallel_args is None:
+        parallel_args = dict()
+
+    results = Parallel(n_jobs=n_jobs, **parallel_args)(
+        delayed(_single_univariate_test)(cm, values, test_fn)
+        for cm in casematches
+    )
+    results = pd.DataFrame.from_records(results)
+    results = results.sort_values(by="test_statistic", ascending=False)
+    return results
+
+
+def _single_permanova(
+    casematch: CaseMatchOneToOne,
+    distance_matrix: DistanceMatrix,
+    permutations: int
+) -> pd.Series:
+    """Evaluate PERMANOVA on single case-control mapping.
+
+    :param casematch: Mapping of cases to controls
+    :type casematch: qupid.CaseMatchOneToOne
+
+    :param distance_matrix: Distance matrix of cases and controls
+    :type distance_matrix: skbio.DistanceMatrix
+
+    :returns: PERMANOVA results
+    :rtype: pd.Series
+    """
+    cases = pd.Series("case", index=list(casematch.cases))
+    controls = pd.Series("control", index=list(casematch.controls))
+    grouping = pd.concat([cases, controls])
+    dm_filt = distance_matrix.filter(grouping.index)
+    pnova_res = permanova(dm_filt, grouping, permutations=permutations)
+    return pnova_res
+
+
+def _single_univariate_test(
+    casematch: CaseMatchOneToOne,
+    values: pd.Series,
+    test_fn: Callable
+):
+    """Evaluate univariate test on single case-control mapping.
+
+    :param casematch: Mapping of cases to controls
+    :type casematch: qupid.CaseMatchOneToOne
+
+    :param values: Numeric values to be used for statistical test
+    :type values: pd.Series
+
+    :param test_fn: Function to use for statistical test
+    :type distance_matrix: Callable
+
+    :returns: Test results
+    :rtype: pd.Series
+    """
+    cases = pd.Series("case", index=list(casematch.cases))
+    controls = pd.Series("control", index=list(casematch.controls))
+    case_vals = values.loc[cases]
+    ctrl_vals = values.loc[controls]
+    res = test_fn(ctrl_vals, case_vals)
+    res = pd.Series(res, index=["test_statistic", "p-value"])
+    return res

--- a/qupid/stats.py
+++ b/qupid/stats.py
@@ -52,7 +52,10 @@ def bulk_permanova(
     ]
     pnova_results = pnova_results.sort_values(by="test_statistic",
                                               ascending=False)
-    return pnova_results
+    col_order = ["method_name", "test_statistic_name", "test_statistic",
+                 "p-value", "sample_size", "number_of_groups",
+                 "number_of_permutations"]
+    return pnova_results[col_order]
 
 
 def bulk_univariate_test(
@@ -88,8 +91,12 @@ def bulk_univariate_test(
     """
     if test in ["t", "ttest", "t-test"]:
         test_fn = ss.ttest_ind
+        method_str = "t-test"
+        stat_str = "t"
     elif test in ["mw", "mannwhitney", "mann-whitney"]:
         test_fn = ss.mannwhitneyu
+        method_str = "mann-whitney"
+        stat_str = "U"
     else:
         raise ValueError(
             "test must be either 't' (t-test) or 'mw' (Mann-Whitney)"
@@ -103,8 +110,14 @@ def bulk_univariate_test(
         for cm in casematches
     )
     results = pd.DataFrame.from_records(results)
+    results["method_name"] = method_str
+    results["test_statistic_name"] = stat_str
+    results["sample_size"] = len(casematches[0].cases) * 2
+    results["number_of_groups"] = 2
     results = results.sort_values(by="test_statistic", ascending=False)
-    return results
+    col_order = ["method_name", "test_statistic_name", "test_statistic",
+                 "p-value", "sample_size", "number_of_groups"]
+    return results[col_order]
 
 
 def _single_permanova(

--- a/qupid/stats.py
+++ b/qupid/stats.py
@@ -43,7 +43,7 @@ def bulk_permanova(
         parallel_args = dict()
 
     pnova_results = Parallel(n_jobs=n_jobs, **parallel_args)(
-        delayed(_single_permanova)(cm, distance_matrix)
+        delayed(_single_permanova)(cm, distance_matrix, permutations)
         for cm in casematches
     )
     pnova_results = pd.DataFrame.from_records(pnova_results)
@@ -135,7 +135,7 @@ def _single_univariate_test(
     casematch: CaseMatchOneToOne,
     values: pd.Series,
     test_fn: Callable
-):
+) -> pd.Series:
     """Evaluate univariate test on single case-control mapping.
 
     :param casematch: Mapping of cases to controls
@@ -150,10 +150,8 @@ def _single_univariate_test(
     :returns: Test results
     :rtype: pd.Series
     """
-    cases = pd.Series("case", index=list(casematch.cases))
-    controls = pd.Series("control", index=list(casematch.controls))
-    case_vals = values.loc[cases]
-    ctrl_vals = values.loc[controls]
-    res = test_fn(ctrl_vals, case_vals)
+    case_vals = values.loc[list(casematch.cases)]
+    ctrl_vals = values.loc[list(casematch.controls)]
+    res = test_fn(case_vals, ctrl_vals)
     res = pd.Series(res, index=["test_statistic", "p-value"])
     return res

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -300,7 +300,6 @@ class TestCaseMatch:
         # Should be 36
         assert len(all_matched_pairs) == 36
 
-
     def test_create_matched_pairs_single(self):
         json_in = os.path.join(os.path.dirname(__file__), "data/test.json")
         match = mm.CaseMatchOneToMany.load_mapping(json_in)

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -5,7 +5,6 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
-from skbio import DistanceMatrix
 
 import qupid._exceptions as mexc
 import qupid.casematch as mm
@@ -174,21 +173,6 @@ class TestErrors:
 
         exp_msg = "The following cases are not one-to-one: ['S1A', 'S2A']"
         assert str(exc_info1.value) == str(exc_info2.value) == exp_msg
-
-    def test_missing_samples_dm(self):
-        ccm = {"S1A": {"S2B", "S3B"}, "S2A": {"S1B", "S4B"}, "S3A": {"S5B"}}
-        dm = DistanceMatrix(np.zeros([5, 5]))
-        dm.ids = ("S1A", "S2A", "S3A", "S1B", "S4B")
-
-        err = mexc.MissingSamplesInDistanceMatrixError
-        with pytest.raises(err) as exc_info:
-            mm.CaseMatchOneToMany(ccm, distance_matrix=dm)
-
-        exp_msg = (
-            "The following samples are missing from the DistanceMatrix: "
-        )
-        assert exp_msg in str(exc_info.value)
-        assert exc_info.value.missing_samples == {"S5B", "S2B", "S3B"}
 
 
 class TestCaseMatch:

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -180,6 +180,20 @@ class TestErrors:
         exp_msg = "Entries must all be of type CaseMatchOneToOne!"
         assert str(exc_info.value) == exp_msg
 
+    @pytest.mark.parametrize(
+        "test_input", [
+            {"A": {"X"}, "B": "Y"},
+            {"A": {5}, "B": {"Y"}},
+            {5: {"X"}, "B": {"Y"}},
+        ]
+    )
+    def test_invalid_input(self, test_input):
+        with pytest.raises(ValueError) as exc_info:
+            mm.CaseMatchOneToOne(test_input)
+
+        exp_err_msg = "Invalid input!"
+        assert str(exc_info.value) == exp_err_msg
+
 
 class TestCaseMatch:
     def test_by_single(self):

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -281,8 +281,11 @@ class TestCaseMatch:
         json_in = os.path.join(os.path.dirname(__file__), "data/test.json")
         match = mm.CaseMatchOneToMany.load(json_in)
         all_matched_pairs = match.create_matched_pairs(iterations=1000)
-        # Should be 36
-        assert len(all_matched_pairs) == 36
+        assert isinstance(all_matched_pairs, mm.CaseMatchCollection)
+
+        # Should be 36 matches
+        match_df = all_matched_pairs.to_dataframe()
+        assert match_df.shape == (len(match.cases), 36)
 
     def test_create_matched_pairs_single(self):
         json_in = os.path.join(os.path.dirname(__file__), "data/test.json")

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -119,7 +119,6 @@ class TestErrors:
         with pytest.raises(mexc.NoMoreControlsError) as exc_info:
             match.create_matched_pairs()
 
-
     def test_no_more_controls_no_strict(self):
         data = {
             "S0A": {"S0B", "S1B", "S2B"},
@@ -134,7 +133,6 @@ class TestErrors:
 
         exp_msg = "Some cases were not matched to a control."
         assert str(warn_info[0].message) == exp_msg
-
 
     def test_multiple_no_tol_map(self):
         focus_cat_1 = ["A", "B", "C", "B", "C"]
@@ -173,6 +171,14 @@ class TestErrors:
 
         exp_msg = "The following cases are not one-to-one: ['S1A', 'S2A']"
         assert str(exc_info1.value) == str(exc_info2.value) == exp_msg
+
+    def test_bad_collection_input(self):
+        cm = mm.CaseMatchOneToOne({"A": {"X"}, "B": {"Y"}})
+        with pytest.raises(ValueError) as exc_info:
+            mm.CaseMatchCollection(["A", "B", cm, 5])
+
+        exp_msg = "Entries must all be of type CaseMatchOneToOne!"
+        assert str(exc_info.value) == exp_msg
 
 
 class TestCaseMatch:

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -166,7 +166,7 @@ class TestErrors:
             json.dump(tmp_ccm, f)
 
         with pytest.raises(mexc.NotOneToOneError) as exc_info1:
-            mm.CaseMatchOneToOne.load_mapping(outfile)
+            mm.CaseMatchOneToOne.load(outfile)
 
         with pytest.raises(mexc.NotOneToOneError) as exc_info2:
             mm.CaseMatchOneToOne(ccm)
@@ -233,14 +233,14 @@ class TestCaseMatch:
             assert set(content["S1A"]) == {"S2B", "S4B"}
             assert set(content["S3A"]) == {"S6B", "S2B"}
 
-    def test_load_mapping(self, tmp_path):
+    def test_load(self, tmp_path):
         inpath = os.path.join(tmp_path, "test.json")
 
         cc_map = {"S1A": ["S2B", "S4B"], "S3A": ["S6B", "S2B"]}
         with open(inpath, "w") as f:
             json.dump(cc_map, f)
 
-        match = mm.CaseMatchOneToMany.load_mapping(inpath)
+        match = mm.CaseMatchOneToMany.load(inpath)
         assert match["S1A"] == {"S2B", "S4B"}
         assert match["S3A"] == {"S6B", "S2B"}
 
@@ -259,7 +259,7 @@ class TestCaseMatch:
         with open(outfile, "w") as f:
             json.dump(tmp_ccm, f)
 
-        cm = mm.CaseMatchOneToOne.load_mapping(outfile)
+        cm = mm.CaseMatchOneToOne.load(outfile)
         assert cm.cases == {"S1A", "S2A", "S3A"}
         assert cm.controls == {"S2B", "S1B", "S5B"}
 
@@ -279,14 +279,14 @@ class TestCaseMatch:
 
     def test_create_matched_pairs(self):
         json_in = os.path.join(os.path.dirname(__file__), "data/test.json")
-        match = mm.CaseMatchOneToMany.load_mapping(json_in)
+        match = mm.CaseMatchOneToMany.load(json_in)
         all_matched_pairs = match.create_matched_pairs(iterations=1000)
         # Should be 36
         assert len(all_matched_pairs) == 36
 
     def test_create_matched_pairs_single(self):
         json_in = os.path.join(os.path.dirname(__file__), "data/test.json")
-        match = mm.CaseMatchOneToMany.load_mapping(json_in)
+        match = mm.CaseMatchOneToMany.load(json_in)
         G = nx.Graph(match.case_control_map)
         matched_pairs = match._create_matched_pairs_single(G, cases=match.cases)
 

--- a/qupid/tests/test_stats.py
+++ b/qupid/tests/test_stats.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pandas as pd
+import pytest
+from skbio import DistanceMatrix
+
+from qupid import CaseMatchOneToOne, CaseMatchOneToMany
+from qupid import stats
+
+CASES = [f"case_{x}" for x in list("ABCDEFGH")]
+CONTROLS = set([f"ctrl_{x}" for x in list("ABCDEFGHIJKLMNOP")])
+N = len(CASES) + len(CONTROLS)
+IDX = CASES + list(CONTROLS)
+
+
+@pytest.fixture
+def example_collection():
+    cc_map = {case: CONTROLS for case in CASES}
+    cm_all = CaseMatchOneToMany(cc_map)
+    cm_coll = cm_all.create_matched_pairs(30)
+    return cm_coll
+
+
+@pytest.fixture
+def example_dm(example_collection):
+    rng = np.random.default_rng()
+    values = rng.beta(1, 1, size=(N, N))
+    dm = np.triu(values, 1) + np.triu(values, 1).T
+    dm = DistanceMatrix(dm, ids=IDX)
+    return dm
+
+
+@pytest.fixture
+def example_vals(example_collection):
+    rng = np.random.default_rng()
+    values = rng.gamma(2, size=N)
+    values = pd.Series(values, index=IDX)
+    return values
+
+
+def test_permanova(example_collection, example_dm):
+    pnova_res = stats.bulk_permanova(example_collection, example_dm)
+    assert pnova_res.shape[0] == 30
+
+    exp_cols = [
+        "method_name",
+        "test_statistic_name",
+        "sample_size",
+        "number_of_groups",
+        "test_statistic",
+        "p-value",
+        "number_of_permutations"
+    ]
+    assert (pnova_res.columns == exp_cols).all()
+
+
+@pytest.mark.parametrize("test", ["t", "mw"])
+def test_univariate(example_collection, example_vals, test):
+    res = stats.bulk_univariate_test(example_collection, example_vals, test)
+    assert res.shape[0] == 30
+
+    exp_cols = ["test_statistic", "p-value"]
+    assert (res.columns == exp_cols).all()

--- a/qupid/tests/test_stats.py
+++ b/qupid/tests/test_stats.py
@@ -41,15 +41,9 @@ def test_permanova(example_collection, example_dm):
     pnova_res = stats.bulk_permanova(example_collection, example_dm)
     assert pnova_res.shape[0] == 30
 
-    exp_cols = [
-        "method_name",
-        "test_statistic_name",
-        "sample_size",
-        "number_of_groups",
-        "test_statistic",
-        "p-value",
-        "number_of_permutations"
-    ]
+    exp_cols = ["method_name", "test_statistic_name", "test_statistic",
+                "p-value", "sample_size", "number_of_groups",
+                "number_of_permutations"]
     assert (pnova_res.columns == exp_cols).all()
 
 
@@ -58,5 +52,6 @@ def test_univariate(example_collection, example_vals, test):
     res = stats.bulk_univariate_test(example_collection, example_vals, test)
     assert res.shape[0] == 30
 
-    exp_cols = ["test_statistic", "p-value"]
+    exp_cols = ["method_name", "test_statistic_name", "test_statistic",
+                "p-value", "sample_size", "number_of_groups"]
     assert (res.columns == exp_cols).all()


### PR DESCRIPTION
Creates `CaseMatchCollection` class that comprises multiple `CaseMatchOneToOne` instances. Leverages this data structure for statistical evaluation of matches for PERMANOVA, t-test, and Mann-Whitney.