### PR TITLE
Add ability to provide arbitrary function to CaseMatchCollection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install conda packages
         shell: bash -l {0}
-        run: conda install -c conda-forge pandas pytest flake8 pytest-cov scipy scikit-bio networkx joblib
+        run: conda install -c conda-forge pandas pytest flake8 pytest-cov scipy scikit-bio networkx joblib h5py==3.1.0
 
       - name: Install qupid
         shell: bash -l {0}

--- a/qupid/casematch.py
+++ b/qupid/casematch.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from functools import partial, reduce
 import json
-from typing import Dict, Set, Union, List, Callable
+from typing import Dict, Set, Union, List, Callable, Iterator
 from warnings import warn
 
 from joblib import Parallel, delayed
@@ -374,7 +374,7 @@ class CaseMatchCollection:
             casematches.append(CaseMatchOneToOne(mapping))
         return cls(casematches)
 
-    def apply(self, func: Callable):
+    def apply(self, func: Callable) -> Iterator:
         """Apply a function to each CaseMatchOneToOne in a collection.
 
         :param func: Function to call on each CaseMatchOneToOne


### PR DESCRIPTION
`CaseMatchCollection` now has a method `apply` to which you can pass a Callable to operate on each `CaseMatchOneToOne`.

Suggestion by @cameronmartino