### PR TITLE
Change options for on_failure

### DIFF
--- a/qupid/_descriptions.py
+++ b/qupid/_descriptions.py
@@ -1,10 +1,12 @@
+VALID_ON_FAILURE_OPTS = ["raise", "warn", "continue"]
+
 FOCUS = "Case samples to be matched."
 BACKGROUND = "Possible control samples to match to cases."
 ITERATIONS = "Number of matching iterations to perform."
 DC = "Discrete category column name."
 NC = "Numeric category column name and tolerance."
-FAIL = ("Whether to raise an error on failure to match a case or "
-        "whether to ignore.")
+FAIL = ("Whether to 'raise' an error, 'warn', or 'continue' (silently) when "
+        "no matches are found for a focus sample.")
 STRICT = ("Whether to perform strict matching such that all cases must be "
           "matched to a control.")
 JOBS = "Number of CPUs to use for parallelization."

--- a/qupid/cli/cli.py
+++ b/qupid/cli/cli.py
@@ -23,7 +23,9 @@ def qupid():
 @click.option("-dc", "--discrete-cat", multiple=True, help=DESC.DC)
 @click.option("-nc", "--numeric-cat", multiple=True, type=(str, float),
               help=DESC.NC)
-@click.option("--raise-on-failure/--ignore-on-failure", default=True,
+@click.option("--on-failure", default="raise",
+              type=click.Choice(DESC.VALID_ON_FAILURE_OPTS,
+                                case_sensitive=False),
               help=DESC.FAIL, show_default=True)
 @click.option("--strict/--no-strict", default=True, help=DESC.STRICT,
               show_default=True)
@@ -37,7 +39,7 @@ def shuffle(
     iterations,
     discrete_cat,
     numeric_cat,
-    raise_on_failure,
+    on_failure,
     strict,
     jobs,
     output
@@ -58,7 +60,7 @@ def shuffle(
         categories=cats,
         tolerance_map=tol_map,
         iterations=iterations,
-        on_failure="raise" if raise_on_failure else "ignore",
+        on_failure=on_failure,
         strict=strict,
         n_jobs=jobs
     )

--- a/qupid/q2/plugin_setup.py
+++ b/qupid/q2/plugin_setup.py
@@ -34,6 +34,8 @@ TOL_DESC = (
     "List of numeric columns and the tolerance within which to match. "
     "Use '+-' to separate column name from value (e.g. age_years+-10)."
 )
+FAIL_OPTS = DESC.VALID_ON_FAILURE_OPTS
+
 
 plugin.methods.register_function(
     function=match_one_to_many,
@@ -45,7 +47,7 @@ plugin.methods.register_function(
         "categories": List[Str],
         "case_identifier": Str,
         "tolerances": List[Str],
-        "on_failure": Str % Choices({"raise", "warn", "continue"})
+        "on_failure": Str % Choices(set(FAIL_OPTS))
     },
     parameter_descriptions={
         "sample_metadata": MD_DESC,
@@ -99,7 +101,7 @@ plugin.pipelines.register_function(
         "categories": List[Str],
         "case_identifier": Str,
         "tolerances": List[Str],
-        "on_match_failure": Str % Choices({"raise", "ignore"}),
+        "on_match_failure": Str % Choices(set(FAIL_OPTS)),
         "iterations": Int,
         "strict": Bool,
         "n_jobs": Int

--- a/qupid/q2/plugin_setup.py
+++ b/qupid/q2/plugin_setup.py
@@ -45,7 +45,7 @@ plugin.methods.register_function(
         "categories": List[Str],
         "case_identifier": Str,
         "tolerances": List[Str],
-        "on_failure": Str % Choices({"raise", "ignore"})
+        "on_failure": Str % Choices({"raise", "warn", "continue"})
     },
     parameter_descriptions={
         "sample_metadata": MD_DESC,

--- a/qupid/qupid.py
+++ b/qupid/qupid.py
@@ -120,8 +120,9 @@ def match_by_multiple(
         for fidx, fhits in observed.items():
             # Reduce the matches with successive categories
             matches[fidx] = matches[fidx] & fhits
-            if not matches[fidx] and on_failure == "raise":
-                raise exc.NoMoreControlsError()
+            if not matches[fidx]:
+                if on_failure == "raise":
+                    raise exc.NoMoreControlsError()
 
     metadata = pd.concat([focus, background])
     return CaseMatchOneToMany(matches, metadata)

--- a/qupid/qupid.py
+++ b/qupid/qupid.py
@@ -7,8 +7,7 @@ import pandas as pd
 from .casematch import CaseMatchOneToMany
 from . import _exceptions as exc
 from . import _casematch_utils as util
-
-VALID_ON_FAILURE_OPTS = ["raise", "warn", "continue"]
+from ._descriptions import VALID_ON_FAILURE_OPTS
 
 
 def match_by_single(
@@ -36,7 +35,7 @@ def match_by_single(
     :returns: Matched control samples
     :rtype: qupid.CaseMatchOneToMany
     """
-    if on_failure not in VALID_ON_FAILURE_OPTS:
+    if on_failure.lower() not in VALID_ON_FAILURE_OPTS:
         raise ValueError(
             "Invalid argument for 'on_failure', must be one of "
             f"{VALID_ON_FAILURE_OPTS}"

--- a/qupid/tests/test_casematch.py
+++ b/qupid/tests/test_casematch.py
@@ -331,15 +331,45 @@ class TestCaseMatch:
         ctrl_lens = [len(v) == 1 for k, v in matched_pairs.items()]
         assert all(ctrl_lens)
 
-    def test_on_failure_ignore(self):
+    def test_on_failure_continue(self):
         s1 = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 100])
         s2 = pd.Series([3, 5, 7, 9, 4, 6, 6, 2, 50])
         s1.index = [f"S{x}A" for x in range(9)]
         s2.index = [f"S{x}B" for x in range(9)]
 
-        match = match_by_single(s1, s2, 1.0, on_failure="ignore")
+        match = match_by_single(s1, s2, 1.0, on_failure="continue")
         exp_match = {
             "S0A": {"S7B"},
+            "S1A": {"S0B", "S7B"},
+            "S2A": {"S0B", "S4B", "S7B"},
+            "S3A": {"S0B", "S1B", "S4B"},
+            "S4A": {"S1B", "S4B", "S5B", "S6B"},
+            "S5A": {"S1B", "S2B", "S5B", "S6B"},
+            "S6A": {"S2B", "S5B", "S6B"},
+            "S7A": {"S2B", "S3B"},
+            "S8A": set()
+        }
+        assert match.case_control_map == exp_match
+
+    def test_on_failure_warn(self):
+        s1 = pd.Series([0, 2, 3, 4, 5, 6, 7, 8, 100])
+        s2 = pd.Series([3, 5, 7, 9, 4, 6, 6, 2, 50])
+        s1.index = [f"S{x}A" for x in range(9)]
+        s2.index = [f"S{x}B" for x in range(9)]
+
+        with pytest.warns(UserWarning) as warn_info:
+            match = match_by_single(s1, s2, 1.0, on_failure="warn")
+
+        warn_msgs = set(map(lambda x: str(x.message), warn_info))
+        assert len(warn_msgs) == 2
+
+        exp_msg_1 = "No matches found for S8A"
+        exp_msg_2 = "No matches found for S0A"
+
+        assert set([exp_msg_1, exp_msg_2]) == warn_msgs
+
+        exp_match = {
+            "S0A": set(),
             "S1A": {"S0B", "S7B"},
             "S2A": {"S0B", "S4B", "S7B"},
             "S3A": {"S0B", "S1B", "S4B"},


### PR DESCRIPTION
Suggestion by @ahdilmore

Previous behavior: two options - `raise` and `ignore` to either stop execution or continue silently, respectively.

New behavior: three options - `raise`, `warn`, and `continue` to either stop execution, show warning per case, or continue silently, respectively.